### PR TITLE
chore: bump jekyll to 4.4 and hydejack to 9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.1"
+gem "jekyll", "~> 4.4"
 
-gem "jekyll-theme-hydejack", "~> 9.0"
+gem "jekyll-theme-hydejack", "~> 9.2"
 
 # IMPORTANT: The followign gem is used to compile math formulas to 
 # KaTeX during site building.


### PR DESCRIPTION
## Dependency Updates

| Gem | Old | New |
|-----|-----|-----|
| jekyll | ~> 4.1 | ~> 4.4 (latest 4.4.1) |
| jekyll-theme-hydejack | ~> 9.0 | ~> 9.2 (latest 9.2.1) |

All other plugins are already at their latest versions.

> Created by JanAssist 🤖